### PR TITLE
fix: handle long water delay and split Excel outputs with >1M rows

### DIFF
--- a/prepshot/_model/hydro.py
+++ b/prepshot/_model/hydro.py
@@ -247,6 +247,9 @@ class AddHydropowerConstraints:
                 t = h - delay
             else:
                 t = hour[-1] + h - delay
+            while t < hour[0]:
+                # when water delay time delay exceeded 24 hours
+                t += int(24/dt)
             up_stream_outflow += model.outflow[ups, t, m, y]
         return up_stream_outflow + model.params['inflow'][s, y, m, h]
 


### PR DESCRIPTION
Made two key fixes to improve model stability and usability:

- Prevented runtime error when water delay time exceeds 24 hours
- Split Excel outputs into multiple sheets when row count exceeds
  1,000,000 to avoid Excel write failures and preserve all results

